### PR TITLE
 Added support for LTE PDU 27, NR PDU 12 & 14, and updated nr_ml1_search_meas_database_update.h to support version 2.7

### DIFF
--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -314,6 +314,12 @@ _decode_lte_rrc_ota(const char *b, int offset, size_t length,
                                      ARRAY_SIZE(LteRrcOtaPacketFmt_v26, Fmt),
                                      b, offset, length, result);
             break;
+        case 27:
+            offset += _decode_by_fmt(LteRrcOtaPacketFmt_v27,
+                                     ARRAY_SIZE(LteRrcOtaPacketFmt_v27, Fmt),
+                                     b, offset, length, result);
+            break;
+
         default:
             printf("(MI)Unknown LTE RRC OTA packet version: %d\n", pkt_ver);
             return 0;
@@ -342,6 +348,26 @@ _decode_lte_rrc_ota(const char *b, int offset, size_t length,
             return (offset - start) + pdu_length;
         }
 
+    } else if (pkt_ver == 27) {
+        int pdu_number = _search_result_int(result, "PDU Number");
+        int pdu_length = _search_result_int(result, "Msg Length");
+
+        const char *type_name = search_name(LteRrcOtaPduType_v27,
+                                            ARRAY_SIZE(LteRrcOtaPduType_v27, ValueName),
+                                            pdu_number);
+
+        if (type_name == NULL) {    // not found
+            printf("(MI)Unknown LTE RRC PDU Type: 0x%x\n", pdu_number);
+            return 0;
+        } else {
+            std::string type_str = "raw_msg/";
+            type_str += type_name;
+            PyObject *t = Py_BuildValue("(sy#s)",
+                                        "Msg", b + offset, pdu_length, type_str.c_str());
+            PyList_Append(result, t);
+            Py_DECREF(t);
+            return (offset - start) + pdu_length;
+        }
     } else if (pkt_ver >= 15) {
 
         int pdu_number = _search_result_int(result, "PDU Number");
@@ -394,7 +420,6 @@ _decode_lte_rrc_mib(const char *b, int offset, size_t length,
                     PyObject *result) {
     int start = offset;
     int pkt_ver = _search_result_int(result, "Version");
-
     switch (pkt_ver) {
         case 1:
             offset += _decode_by_fmt(LteRrcMibMessageLogPacketFmt_v1,
@@ -11392,6 +11417,9 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
 
     //pkt_ver==8 (Xiaomi)
     if (pkt_ver == 8) {
+        offset += _decode_by_fmt(NrRrcOtaPacketFmt_v1,
+                                     ARRAY_SIZE(NrRrcOtaPacketFmt_v1, Fmt),
+                                     b, offset, length, result);
 
         int pdu_number = _search_result_int(result, "PDU Number");
         int pdu_length = _search_result_int(result, "Msg Length");
@@ -11423,6 +11451,9 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
         }
 
     } else if (pkt_ver == 7) {
+        offset += _decode_by_fmt(NrRrcOtaPacketFmt_v1,
+                                     ARRAY_SIZE(NrRrcOtaPacketFmt_v1, Fmt),
+                                     b, offset, length, result);
         //pkt_ver==8 (Samsung)
         int pdu_number = _search_result_int(result, "PDU Number");
         int pdu_length = _search_result_int(result, "Msg Length");
@@ -11454,6 +11485,9 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
     }
     
     else if (pkt_ver == 9) {
+        offset += _decode_by_fmt(NrRrcOtaPacketFmt_v1,
+                                     ARRAY_SIZE(NrRrcOtaPacketFmt_v1, Fmt),
+                                     b, offset, length, result);
         //pkt_ver==9 (America)
         int pdu_number = _search_result_int(result, "PDU Number");
         int pdu_length = _search_result_int(result, "Msg Length");
@@ -11484,6 +11518,60 @@ _decode_nr_rrc_ota(const char *b, int offset, size_t length,
                 t = Py_BuildValue("(sy#s)",
                     "Msg", b + offset, pdu_length, type_str.c_str());
             }
+            PyList_Append(result, t);
+            Py_DECREF(t);
+            return (offset - start) + pdu_length;
+        }
+    }
+    else if (pkt_ver == 12) {
+        //Sierra Wireless EM9191
+
+        offset += _decode_by_fmt(NrRrcOtaPacketFmt_v12,
+                                     ARRAY_SIZE(NrRrcOtaPacketFmt_v12, Fmt),
+                                     b, offset, length, result);
+        
+        int pdu_number = _search_result_int(result, "PDU Number");
+        int pdu_length = _search_result_int(result, "Msg Length");
+
+        const char *type_name = search_name(NrRrcOtaPduType_v12,
+                                            ARRAY_SIZE(NrRrcOtaPduType_v12, ValueName),
+                                            pdu_number);
+
+        if (type_name == NULL) {    // not found
+            printf("(MI)Unknown NR RRC PDU Type: 0x%x\n", pdu_number);
+            return 0;
+        } else {
+            std::string type_str = "raw_msg/";
+            type_str += type_name;
+            PyObject *t = Py_BuildValue("(sy#s)",
+                                        "Msg", b + offset, pdu_length, type_str.c_str());
+            PyList_Append(result, t);
+            Py_DECREF(t);
+            return (offset - start) + pdu_length;
+        }
+    }
+    else if (pkt_ver == 14) {
+        //SIMCOM 8262A-M2
+
+        offset += _decode_by_fmt(NrRrcOtaPacketFmt_v14,
+                                     ARRAY_SIZE(NrRrcOtaPacketFmt_v14, Fmt),
+                                     b, offset, length, result);
+        
+        int pdu_number = _search_result_int(result, "PDU Number");
+        int pdu_length = _search_result_int(result, "Msg Length");
+
+        const char *type_name = search_name(NrRrcOtaPduType_v14,
+                                            ARRAY_SIZE(NrRrcOtaPduType_v14, ValueName),
+                                            pdu_number);
+
+        if (type_name == NULL) {    // not found
+            printf("(MI)Unknown NR RRC PDU Type: 0x%x\n", pdu_number);
+            return 0;
+        } else {
+            std::string type_str = "raw_msg/";
+            type_str += type_name;
+            PyObject *t = Py_BuildValue("(sy#s)",
+                                        "Msg", b + offset, pdu_length, type_str.c_str());
             PyList_Append(result, t);
             Py_DECREF(t);
             return (offset - start) + pdu_length;
@@ -11733,7 +11821,7 @@ on_demand_decode (const char *b, size_t length, LogPacketType type_id, PyObject*
             offset += _decode_by_fmt(LteRrcOtaPacketFmt,
                                      ARRAY_SIZE(LteRrcOtaPacketFmt, Fmt),
                                      b, offset, length, result);
-            offset += _decode_lte_rrc_ota(b, offset, length, result);
+	        offset += _decode_lte_rrc_ota(b, offset, length, result);
             break;
 
         case LTE_RRC_MIB_Message_Log_Packet:
@@ -12290,6 +12378,7 @@ on_demand_decode (const char *b, size_t length, LogPacketType type_id, PyObject*
             offset += _decode_gnss_gal_payload(b, offset, length, result);
             break;         
         default:
+	    printf("Not a valid case statement in log_packet.cpp\n");
             break;
     };
 
@@ -12345,6 +12434,8 @@ decode_log_packet(const char *b, size_t length, bool skip_decoding) {
             ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName),
             "Unsupported");
 
+    printf("found %d type\n", type_id);
+
     /*
     if (skip_decoding) {    // skip further decoding
 
@@ -12357,6 +12448,8 @@ decode_log_packet(const char *b, size_t length, bool skip_decoding) {
     }
     */
 
+    printf("%s\n", b);
+    printf("%d\n", length);
     on_demand_decode(b + offset, length - offset, type_id, result);
 
     return result;

--- a/dm_collector_c/log_packet.cpp
+++ b/dm_collector_c/log_packet.cpp
@@ -12378,7 +12378,7 @@ on_demand_decode (const char *b, size_t length, LogPacketType type_id, PyObject*
             offset += _decode_gnss_gal_payload(b, offset, length, result);
             break;         
         default:
-	    printf("Not a valid case statement in log_packet.cpp\n");
+	        printf("Not a valid case statement in log_packet.cpp\n");
             break;
     };
 
@@ -12434,7 +12434,6 @@ decode_log_packet(const char *b, size_t length, bool skip_decoding) {
             ARRAY_SIZE(LogPacketTypeID_To_Name, ValueName),
             "Unsupported");
 
-    printf("found %d type\n", type_id);
 
     /*
     if (skip_decoding) {    // skip further decoding
@@ -12448,8 +12447,6 @@ decode_log_packet(const char *b, size_t length, bool skip_decoding) {
     }
     */
 
-    printf("%s\n", b);
-    printf("%d\n", length);
     on_demand_decode(b + offset, length - offset, type_id, result);
 
     return result;

--- a/dm_collector_c/log_packet.h
+++ b/dm_collector_c/log_packet.h
@@ -372,6 +372,19 @@ const Fmt LteRrcOtaPacketFmt_v26[] = {
         {SKIP, NULL,                          3},
         {UINT, "Msg Length",                  2}
 };
+const Fmt LteRrcOtaPacketFmt_v27[] = {
+        {BYTE_STREAM, "RRC Version Number",   1}, 
+        {UINT, "NR RRC Release Number",       1},
+        {BYTE_STREAM, "NR RRC Version Number",1},
+        {UINT, "Radio Bearer ID",             1},
+        {UINT, "Physical Cell ID",            2},    //Cell ID
+        {UINT, "Freq",                        2},    //frequency
+        {UINT, "SysFrameNum/SubFrameNum",     4},    //System/subsystem frame number 
+        {UINT, "PDU Number",                  1},    //PDU number
+        {UINT, "SIB Mask in SI",              1},
+        {SKIP, NULL,                          3},
+        {UINT, "Msg Length",                  2}
+};
 
 const ValueName LteRrcOtaPduType[] = {
         {0x02, "LTE-RRC_BCCH_DL_SCH"},
@@ -383,6 +396,7 @@ const ValueName LteRrcOtaPduType[] = {
 };
 
 const ValueName LteRrcOtaPduType_v15[] = {
+        {0x03, "LTE-RRC_BCCH_DL_SCH"},
         {0x02, "LTE-RRC_BCCH_DL_SCH"},
         {0x05, "LTE-RRC_PCCH"},
         {0x06, "LTE-RRC_DL_CCCH"},
@@ -406,18 +420,62 @@ const ValueName LteRrcOtaPduType_v19[] = {
         {0x32, "LTE-RRC_UL_CCCH_NB"},
 };
 
+//added fields for version 27
+const ValueName LteRrcOtaPduType_v27[] = {
+        {0x03, "LTE-RRC_BCCH_DL_SCH"},
+        {0x07, "LTE-RRC_PCCH"},
+        {0x08, "LTE-RRC_DL_CCCH"},
+        {0x09, "LTE-RRC_DL_DCCH"},
+        {0x0a, "LTE-RRC_UL_CCCH"},
+        {0x0b, "LTE-RRC_UL_DCCH"},
+        {0x2e, "LTE-RRC_BCCH_DL_SCH_NB"},
+        {0x30, "LTE-RRC_DL_CCCH_NB"},
+        {0x31, "LTE-RRC_DL_DCCH_NB"},
+        {0x34, "LTE-RRC_UL_DCCH_NB"},
+        {0x32, "LTE-RRC_UL_CCCH_NB"},
+};
+
 
 // ------------------------------------------------------------
 // NR_RRC_OTA_Packet
 const Fmt NrRrcOtaPacketFmt[] = {
         {UINT, "Pkt Version",        1},    //version
         {UINT, "Unknown", 			 3},    //Maybe Reserved
+};
+
+const Fmt NrRrcOtaPacketFmt_v1[] = {
         {UINT, "RRC Release Number", 1},    //RRC release version
         {BYTE_STREAM, "RRC Version Number", 1},    //RRC version version
         {UINT, "Radio Bearer ID",    1},    //no change
         {UINT, "Physical Cell ID",   2},     //Cell ID
         {UINT, "Freq",   			 4},     //Freq
-        {UINT, "SysFrameNum/SubFrameNum",   4},     //System/subsystem frame number
+        {UINT, "SysFrameNum/SubFrameNum",   4},  //System/subsystem frame number
+        {UINT, "PDU Number",         1},     //PDU Number
+        {UINT, "SIB Mask in SI",     1},
+        {SKIP, NULL,                 3},
+        {UINT, "Msg Length",         2}
+};
+
+const Fmt NrRrcOtaPacketFmt_v12[] = {
+        {UINT, "RRC Release Number", 1},    //RRC release version
+        {BYTE_STREAM, "RRC Version Number", 1},    //RRC version version
+        {UINT, "Radio Bearer ID",    1},    //no change
+        {UINT, "Physical Cell ID",   2},     //Cell ID
+        {UINT, "Freq",   			 4},     //Freq
+        {UINT, "SysFrameNum/SubFrameNum",   3},     //System/subsystem frame number
+        {UINT, "PDU Number",         1},     //PDU Number
+        {UINT, "SIB Mask in SI",     1},
+        {SKIP, NULL,                 3},
+        {UINT, "Msg Length",         2}
+};
+
+const Fmt NrRrcOtaPacketFmt_v14[] = {
+        {UINT, "RRC Release Number", 1},    //RRC release version
+        {BYTE_STREAM, "RRC Version Number", 1},    //RRC version version
+        {UINT, "Radio Bearer ID",    1},    //no change
+        {UINT, "Physical Cell ID",   2},     //Cell ID
+        {UINT, "Freq",   			 4},     //Freq
+        {UINT, "SysFrameNum/SubFrameNum",   3},     //System/subsystem frame number
         {UINT, "PDU Number",         1},     //PDU Number
         {UINT, "SIB Mask in SI",     1},
         {SKIP, NULL,                 3},
@@ -485,6 +543,55 @@ const ValueName NrRrcOtaPduType_v9[] = {
         // {0x00, "nr-rrc.ue_mrdc_cap"}, // unknown so far
         // {0x00, "nr-rrc.ue_nr_cap"}, // unknown so far
 };
+const ValueName NrRrcOtaPduType_v12[] = {
+
+        // {0x00, "nr-rrc.ue_radio_paging_info"}, // unknown so far
+        // {0x00, "nr-rrc.ue_radio_access_cap_info"}, // unknown so far
+        // {0x00, "nr-rrc.bcch.dl.sch"},
+        // {0x00, "nr-rrc.dl.ccch"},
+        // {0x00, "nr-rrc.dl.dcch"},
+        // {0x00, "nr-rrc.pcch"},
+        // {0x00, "nr-rrc.ul.ccch"},
+        // {0x00, "nr-rrc.ul.ccch1"},
+        {0x01, "nr-rrc.bcch.bch"},  // MIB
+	    {0x02,"nr-rrc.bcch.dl.sch"},
+	    {0x03,"nr-rrc.dl.ccch"},
+	    {0x04,"nr-rrc.dl.dcch"},
+	    {0x05,"nr-rrc.pcch"},
+	    {0x06,"nr-rrc.ul.ccch"},
+        {0x0a, "nr-rrc.ul.dcch"},   // RRC Reconfiguration Complete
+        {0x08, "nr-rrc.ul.dcch"},   // Derived from measurement report (uplink, dedicated link)
+	
+       	{0x09, "nr-rrc.rrc_reconf"}, // Reconfiguration message
+        {0x19, "nr-rrc.radio_bearer_conf"}, // Radio Bearer Config
+        // {0x00, "nr-rrc.ue_mrdc_cap"}, // unknown so far
+        // {0x00, "nr-rrc.ue_nr_cap"}, // unknown so far
+};
+const ValueName NrRrcOtaPduType_v14[] = {
+
+        // {0x00, "nr-rrc.ue_radio_paging_info"}, // unknown so far
+        // {0x00, "nr-rrc.ue_radio_access_cap_info"}, // unknown so far
+        // {0x00, "nr-rrc.bcch.dl.sch"},
+        // {0x00, "nr-rrc.dl.ccch"},
+        // {0x00, "nr-rrc.dl.dcch"},
+        // {0x00, "nr-rrc.pcch"},
+        // {0x00, "nr-rrc.ul.ccch"},
+        // {0x00, "nr-rrc.ul.ccch1"},
+        {0x01, "nr-rrc.bcch.bch"},  // MIB
+	    {0x02,"nr-rrc.bcch.dl.sch"},
+	    {0x03,"nr-rrc.dl.ccch"},
+	    {0x04,"nr-rrc.dl.dcch"},
+	    {0x05,"nr-rrc.pcch"},
+	    {0x06,"nr-rrc.ul.ccch"},
+        {0x0a, "nr-rrc.ul.dcch"},   // RRC Reconfiguration Complete
+        {0x08, "nr-rrc.ul.dcch"},   // Derived from measurement report (uplink, dedicated link)
+	
+       	{0x09, "nr-rrc.rrc_reconf"}, // Reconfiguration message
+        {0x19, "nr-rrc.radio_bearer_conf"}, // Radio Bearer Config
+        // {0x00, "nr-rrc.ue_mrdc_cap"}, // unknown so far
+        // {0x00, "nr-rrc.ue_nr_cap"}, // unknown so far
+};
+
 // ------------------------------------------------------------
 // LTE NAS Plain
 const Fmt LteNasPlainFmt[] = {

--- a/dm_collector_c/nr_ml1_search_meas_database_update.h
+++ b/dm_collector_c/nr_ml1_search_meas_database_update.h
@@ -9,6 +9,16 @@
 const Fmt NrMl1SearchMeasDatabaseUpdate_Fmt [] = {
     {UINT, "Minor Version",                 2},
     {UINT, "Major Version",                 2},
+};
+
+const Fmt NrMl1SearchMeasDatabaseUpdateCont_Fmt [] = {
+    {UINT, "Num Layers",                 1},
+    {UINT,"SSB Periodicity Serv Cell",   1},
+    {SKIP,           NULL,                   2},
+};
+
+const Fmt NrMl1SearchMeasDatabaseUpdate_Fmt_v2_9 [] = {
+    {UINT, "UNKNOWN",                    4}, 
     {UINT, "Num Layers",                 1},
     {UINT,"SSB Periodicity Serv Cell",   1},
     {SKIP,           NULL,                   2},
@@ -99,6 +109,51 @@ const Fmt NrMl1SearchMeasDetectedBeam_v2_7[] = {
 
 };
 
+const Fmt NrMl1SearchMeasFmtsubpkt_v2_9[] = {
+    {UINT,"Frequency Offset",4},
+    {UINT,"Timing Offset",4},
+};
+const Fmt NrMl1SearchMeasCarrierList_v2_9[] = {
+    {UINT,"Raster ARFCN",4},
+    {UINT,"Serving Cell Index",1},
+    {UINT,"Num Cells",1},
+    {UINT,"Serving Cell PCI",2},
+    {UINT,"Serving SSB",1},
+    {SKIP,NULL,3},
+    {UINT,"ServingRsrpRx23[0]",4},
+    {UINT,"ServingRsrpRx23[1]",4},
+    {UINT,"Serving RX Beam[0]",2},
+    {UINT,"Serving RX Beam[1]",2},
+    {UINT,"Serving RFIC ID",2},
+    {SKIP,NULL,2},
+    {UINT,"ServingSubarrayId[0]",2},
+    {UINT,"ServingSubarrayId[1]",2},
+};
+const Fmt NrMl1SearchMeasCellList_v2_9[] = {
+    {UINT,"PCI",2},
+    {UINT,"PBCH SFN",2},
+    {UINT,"Num Beams",1},
+    {SKIP,NULL,3},
+    {UINT,"Cell Quality Rsrp",4},
+    {UINT,"Cell Quality Rsrq",4},
+};
+
+const Fmt NrMl1SearchMeasDetectedBeam_v2_9[] = {
+    {UINT,"SSB Index",2},
+    {SKIP,NULL,2},
+    {UINT,"Rx Beam Id[0]",2},
+    {UINT,"Rx Beam Id[1]",2},
+    {SKIP,NULL,4},
+    {BYTE_STREAM_LITTLE_ENDIAN,"SSB Ref Timing ",8},
+    {UINT,"RX Beam Info-RSRPs[0]",4},
+    {UINT,"RX Beam Info-RSRPs[1]",4},
+    {UINT,"Nr2NrFilteredBeamRsrpL3",4},
+    {UINT,"Nr2NrFilteredBeamRsrqL3",4},
+    {UINT,"L2NrFilteredTxBeamRsrpL3",4},
+    {UINT,"L2NrFilteredTxBeamRsrqL3",4},
+
+};
+
 static void
 _convert_nr_rsrp_rsrq_v2_7(PyObject * obj, const char* rsrp_field) {
     int utemp = _search_result_uint(obj, rsrp_field);
@@ -141,6 +196,17 @@ _decode_nr_ml1_search_meas_subpkt(const char *b, int offset, size_t length,
     int start = offset;
     int major_ver = _search_result_int(result, "Major Version");
     int minor_ver = _search_result_int(result, "Minor Version");
+
+    if ((major_ver == 2) && (minor_ver == 9)){
+        offset += _decode_by_fmt(NrMl1SearchMeasDatabaseUpdate_Fmt_v2_9,
+                        ARRAY_SIZE(NrMl1SearchMeasDatabaseUpdate_Fmt_v2_9, Fmt),
+                        b, offset, length, result);
+    }else{
+        offset += _decode_by_fmt(NrMl1SearchMeasDatabaseUpdateCont_Fmt,
+                        ARRAY_SIZE(NrMl1SearchMeasDatabaseUpdateCont_Fmt, Fmt),
+                        b, offset, length, result);
+    }
+
     int n_layer = _search_result_int(result, "Num Layers");
     bool success = false;
 
@@ -328,12 +394,106 @@ _decode_nr_ml1_search_meas_subpkt(const char *b, int offset, size_t length,
                     success = true;
                     break;
                 }
+                
+                case 9:
+                {
+                    PyObject* result_allcarriers = PyList_New(0);
+                    PyObject* t = NULL;
+                    _judge_na_v2_7(result,"SSB Periodicity Serv Cell",0x00);
+                    offset += _decode_by_fmt(NrMl1SearchMeasFmtsubpkt_v2_9,
+                        ARRAY_SIZE(NrMl1SearchMeasFmtsubpkt_v2_9, Fmt),
+                        b, offset, length, result);
+                    int temp = _search_result_int(result, "Frequency Offset");
+                    float t_offset = temp * 0.0009766;
+                    char f_offset[64];
+                    sprintf(f_offset,"%.3f PPM",t_offset);
+                    PyObject* pyfloat = Py_BuildValue("s", f_offset);
+                    PyObject* old_object = _replace_result(result, "Frequency Offset", pyfloat);
+                    Py_DECREF(old_object);
+                    Py_DECREF(pyfloat);
+                    for (int i = 0; i < n_layer; i++) {
+                        PyObject* result_layer = PyList_New(0);
+                        offset += _decode_by_fmt(NrMl1SearchMeasCarrierList_v2_9,
+                            ARRAY_SIZE(NrMl1SearchMeasCarrierList_v2_9, Fmt),
+                            b, offset, length, result_layer);
+
+                        int n_cells = _search_result_int(result_layer, "Num Cells");
+                        PyObject* result_allcells = PyList_New(0);
+                        _convert_nr_rsrp_rsrq_v2_7(result_layer, "ServingRsrpRx23[0]");
+                        _convert_nr_rsrp_rsrq_v2_7(result_layer, "ServingRsrpRx23[1]");
+
+                        _judge_na_v2_7(result_layer, "Serving SSB", 0xff);
+                        _judge_na_v2_7(result_layer, "Serving RX Beam[0]", 0xffff);
+                        _judge_na_v2_7(result_layer, "Serving RX Beam[1]", 0xffff);
+                        _judge_na_v2_7(result_layer, "Serving RFIC ID", 0xffff);
+                        _judge_na_v2_7(result_layer, "ServingSubarrayId[0]", 0xffff);
+                        _judge_na_v2_7(result_layer, "ServingSubarrayId[1]", 0xffff);
+                        for (int j = 0; j < n_cells; j++) {
+
+                            PyObject* result_cell = PyList_New(0);
+                            offset += _decode_by_fmt(NrMl1SearchMeasCellList_v2_7,
+                                ARRAY_SIZE(NrMl1SearchMeasCellList_v2_7, Fmt),
+                                b, offset, length, result_cell);
+                            _convert_nr_rsrp_rsrq_v2_7(result_cell, "Cell Quality Rsrp");
+                            _convert_nr_rsrp_rsrq_v2_7(result_cell, "Cell Quality Rsrq");
+                            int n_beams = _search_result_int(result_cell, "Num Beams");
+                            for (int k = 0; k < n_beams; k++) {
+                                PyObject* result_beam = PyList_New(0);
+                                offset += _decode_by_fmt(NrMl1SearchMeasDetectedBeam_v2_7,
+                                    ARRAY_SIZE(NrMl1SearchMeasDetectedBeam_v2_7, Fmt),
+                                    b, offset, length, result_beam);
+                                _judge_na_v2_7(result_beam,"Rx Beam Id[0]",0x0000);
+                                _judge_na_v2_7(result_beam,"Rx Beam Id[1]",0x0000);
+                                _convert_nr_rsrp_rsrq_v2_7(result_beam, "RX Beam Info-RSRPs[0]");
+                                _convert_nr_rsrp_rsrq_v2_7(result_beam, "RX Beam Info-RSRPs[1]");
+                                _convert_nr_rsrp_rsrq_v2_7(result_beam, "Nr2NrFilteredBeamRsrpL3");
+                                _convert_nr_rsrp_rsrq_v2_7(result_beam, "Nr2NrFilteredBeamRsrqL3");
+                                _convert_nr_rsrp_rsrq_v2_7(result_beam, "L2NrFilteredTxBeamRsrpL3");
+                                _convert_nr_rsrp_rsrq_v2_7(result_beam, "L2NrFilteredTxBeamRsrqL3");
+                                char name_beam[64];
+                                sprintf(name_beam, "Beams[%d]", k);
+                                PyObject* t_beam = Py_BuildValue("(sOs)", name_beam, result_beam, "dict");
+                                PyList_Append(result_cell, t_beam);
+
+                                Py_DECREF(t_beam);
+                                Py_DECREF(result_beam);
+                            }
+                            char name_cell[64];
+                            sprintf(name_cell, "Cells[%d]", j);
+                            PyObject* t_cell = Py_BuildValue("(sOs)", name_cell, result_cell, "dict");
+                            PyList_Append(result_allcells, t_cell);
+
+                            Py_DECREF(t_cell);
+                            Py_DECREF(result_cell);
+                        }
+                        PyObject* t_allcells = Py_BuildValue("(sOs)", "Cells", result_allcells, "list");
+
+                        PyList_Append(result_layer, t_allcells);
+
+                        char name[64];
+                        sprintf(name, "Component_Carrier List[%d]", i);
+                        t = Py_BuildValue("(sOs)", name, result_layer, "dict");
+
+                        PyList_Append(result_allcarriers, t);
+
+                        Py_DECREF(result_allcells);
+                        Py_DECREF(t);
+                        Py_DECREF(t_allcells);
+                        Py_DECREF(result_layer);
+                    }
+                    t = Py_BuildValue("(sOs)", "Component_Carrier List", result_allcarriers, "list");
+                    PyList_Append(result, t);
+                    Py_DECREF(t);
+                    Py_DECREF(result_allcarriers);
+                    success = true;
+                    break;
+                }
                 default:
                     break;
 
             }
 
-            
+
         }
         default:
             break;


### PR DESCRIPTION
NR_RRC_OTA_Packet now supports PDU 12 and 14. 
LTE_RRC_OTA_Packet support for PDU 27 was added.
nr_ml1_search_meas_database_update.h was modified to support 2.7.

These changes were found using a Simcom 8262 and a Sierra Wireless EM9191.